### PR TITLE
#9, #11 対応

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -12,33 +12,33 @@
 <div class="container">
     <div class="btn-group">
         <nav>
-            <a routerLink="./input-nodes" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">格点</a>
-            <a routerLink="./input-fix_nodes" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">支点</a>
-            <a routerLink="./input-members" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">部材</a>
-            <a routerLink="./input-elements" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">材料</a>
-            <a routerLink="./input-joints" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">結合</a>
-            <a routerLink="./input-notice_points" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">着目点</a>
-            <a routerLink="./input-fix_members" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">バネ</a>
+            <a routerLink="./input-nodes" (click)="contentsDailogShow(0)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="0">格点</a>
+            <a routerLink="./input-fix_nodes" (click)="contentsDailogShow(1)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="1">支点</a>
+            <a routerLink="./input-members" (click)="contentsDailogShow(2)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="2">部材</a>
+            <a routerLink="./input-elements" (click)="contentsDailogShow(3)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="3">材料</a>
+            <a routerLink="./input-joints" (click)="contentsDailogShow(4)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="4">結合</a>
+            <a routerLink="./input-notice_points" (click)="contentsDailogShow(5)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="5">着目点</a>
+            <a routerLink="./input-fix_members" (click)="contentsDailogShow(6)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="6">バネ</a>
 
-            <a routerLink="./input-load-name" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">荷重</a>
+            <a routerLink="./input-load-name" (click)="contentsDailogShow(7)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="7">荷重</a>
                 
-            <a routerLink="./input-define" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">組合せ</a>
+            <a routerLink="./input-define" (click)="contentsDailogShow(8)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="8">組合せ</a>
 
-            <a routerLink="./result-disg" *ngIf="isCalculated" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">変位</a>
-            <a routerLink="./result-reac" *ngIf="isCalculated" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">支点反力</a>
-            <a routerLink="./result-fsec" *ngIf="isCalculated" (click)="contentsDailogShow()" routerLinkActive="selected-item"
-                class="btn btn-outline-primary">基本荷重断面力</a>
+            <a routerLink="./result-disg" *ngIf="isCalculated" (click)="contentsDailogShow(9)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="9">変位</a>
+            <a routerLink="./result-reac" *ngIf="isCalculated" (click)="contentsDailogShow(10)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="10">支点反力</a>
+            <a routerLink="./result-fsec" *ngIf="isCalculated" (click)="contentsDailogShow(11)" routerLinkActive="selected-item"
+                class="btn btn-outline-primary" id="11">基本荷重断面力</a>
         </nav>
     </div>
 </div>
@@ -47,8 +47,9 @@
     <app-unity #unityView></app-unity>
 </div>
 
-<div cdkDrag *ngIf="isContentsDailogShow" class="contents-dailog">
+<div cdkDrag *ngIf="isContentsDailogShow" class="contents-dailog" id="contents-dialog-id">
+    <!-- ドラッグハンドルをテーブルの後ろに敷いて、テーブル領域以外がドラッグされたらcontetns-dialogを移動するイメージ -->
+    <div cdkDragHandle class="dialog-drag-handle"></div>
     <button (click)="dialogClose()" class="dialog-close-button"></button>
     <router-outlet></router-outlet>
 </div>
-

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -53,6 +53,9 @@ h1 {
   top: 150px;
   margin: 0;
   z-index: 10;
+  overflow: scroll;
+  display: inline;
+  resize:both;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),
@@ -90,4 +93,10 @@ h1 {
 }
 .dialog-close-button:after {
   transform: rotate(-45deg);
+}
+
+.dialog-drag-handle {
+  position: absolute;
+  width:100%;
+  height:100%;
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -46,9 +46,45 @@ export class AppComponent {
 
   dialogClose(): void{
     this.isContentsDailogShow = false;
+    this.deactiveButtons();
   }
 
-  contentsDailogShow(): void{
+  contentsDailogShow(id): void{
+
+    this.deactiveButtons();
+
+    document.getElementById(id).classList.add("active");
+    
     this.isContentsDailogShow = true;
+    this.setDialogHeight();
+  }
+
+  // アクティブになっているボタンを全て非アクティブにする
+  deactiveButtons() {
+    for(var i = 0; i <= 11; i++) {
+      var data = document.getElementById(i+"");
+      if (data != null) {
+        if (data.classList.contains("active")) {
+          data.classList.remove("active");
+        }
+      }
+    }
+  }
+
+  // contents-dialogの高さをウィンドウサイズに合わせる
+  setDialogHeight() {
+
+    setTimeout(function () {
+      var dialog = document.getElementById('contents-dialog-id');
+      // ヘッダ領域を取得
+      var header = document.getElementsByClassName('header');
+      var container = document.getElementsByClassName('container');
+      var headerSize = container[0].clientHeight + header[0].clientHeight + 30;
+
+      dialog.style.height = window.innerHeight - headerSize +"px";
+      console.log("dialog height:"+dialog.style.height);
+
+    }, 100);
+
   }
 }

--- a/src/app/components/input-combine/input-combine.component.html
+++ b/src/app/components/input-combine/input-combine.component.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <nav>
     <a routerLink="/input-define" routerLinkActive="selected-item" class="btn btn-outline-primary">DEFINE</a>
-    <a routerLink="/input-combine" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
+    <a routerLink="/input-combine" routerLinkActive="selected-item" class="btn btn-outline-primary active">COMBINE</a>
     <a routerLink="/input-pickup" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>
 </div>
@@ -18,6 +18,7 @@
   [colHeaders]="true" 
   [rowHeaders]="rowHeaders" 
   [height]="500"
+  [width]="900"
   [settings]="hotTableSettings">
     <hot-column *ngFor="let c of combineColums; index as i" [data]="c" [title]="combineTitles[i]"></hot-column>
   </hot-table>

--- a/src/app/components/input-combine/input-combine.component.scss
+++ b/src/app/components/input-combine/input-combine.component.scss
@@ -1,8 +1,12 @@
 .btn-group {
-    width: 500px;
     margin-top: 15px;
     margin-bottom: 15px;
     margin-left: 15px;
+
+    display: inline-block;
+    position:absolute;
+    width:30%;
+    left:0px;
 }
 
 .pager {
@@ -12,6 +16,8 @@
     .pager-title{
         float:left;
     }
+
+    display: inline-block;
 }
 
 .datasheet{

--- a/src/app/components/input-define/input-define.component.html
+++ b/src/app/components/input-define/input-define.component.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <nav>
     <a routerLink="/input-define" routerLinkActive="selected-item"
-      class="btn btn-outline-primary">DEFINE</a>
+      class="btn btn-outline-primary active">DEFINE</a>
     <a routerLink="/input-combine" routerLinkActive="selected-item"
       class="btn btn-outline-primary">COMBINE</a>
     <a routerLink="/input-pickup" routerLinkActive="selected-item"
@@ -9,19 +9,22 @@
   </nav>
 </div>
 
-<div class="pager">
-  <div class="pager-title">ページ</div>
-  <ngb-pagination [collectionSize]="70" [(page)]="page" aria-label="Default pagination" (pageChange)="loadPage($event)">
-  </ngb-pagination>
-</div>
+<div style="width:900px;">
+  <div class="pager">
+    <div class="pager-title">ページ</div>
+    <ngb-pagination [collectionSize]="70" [(page)]="page" aria-label="Default pagination" (pageChange)="loadPage($event)">
+    </ngb-pagination>
+  </div>
 
-<div class="datasheet">
-  <hot-table class="hot" 
-  [data]="defineData" 
-  [colHeaders]="true"
-  [rowHeaders]="rowHeaders" 
-  [height]="500"
-  [settings]="hotTableSettings">
-    <hot-column *ngFor="let c of defineColums;" [data]="c" [title]="c"></hot-column>
-  </hot-table>
+  <div class="datasheet">
+    <hot-table class="hot" 
+    [data]="defineData" 
+    [colHeaders]="true"
+    [rowHeaders]="rowHeaders" 
+    [height]="500"
+    [width]="300"
+    [settings]="hotTableSettings">
+      <hot-column *ngFor="let c of defineColums;" [data]="c" [title]="c"></hot-column>
+    </hot-table>
+  </div>
 </div>

--- a/src/app/components/input-define/input-define.component.scss
+++ b/src/app/components/input-define/input-define.component.scss
@@ -1,8 +1,12 @@
 .btn-group {
-    width: 500px;
     margin-top: 15px;
     margin-bottom: 15px;
     margin-left: 15px;
+
+    display: inline-block;
+    position:absolute;
+    width:30%;
+    left:0px;
 }
 
 .pager {
@@ -12,6 +16,8 @@
     .pager-title{
         float:left;
     }
+    
+    display: inline-block;
 }
 
 .datasheet{

--- a/src/app/components/input-load-name/input-load-name.component.html
+++ b/src/app/components/input-load-name/input-load-name.component.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
   <nav>
-    <a routerLink="/input-load-name" routerLinkActive="selected-item" class="btn btn-outline-primary">荷重名称</a>
+    <a routerLink="/input-load-name" routerLinkActive="selected-item" class="btn btn-outline-primary active">荷重名称</a>
     <a routerLink="/input-loads" routerLinkActive="selected-item" class="btn btn-outline-primary">荷重強度</a>
   </nav>
 </div>

--- a/src/app/components/input-load-name/input-load-name.component.scss
+++ b/src/app/components/input-load-name/input-load-name.component.scss
@@ -5,13 +5,21 @@
     .pager-title{
         float:left;
     }
+
+    display: inline-block;
+    width:30%;
+    right:0px;
 }
 
 .btn-group {
-    width: 500px;
     margin-top: 15px;
     margin-bottom: 15px;
     margin-left: 15px;
+
+    display: inline-block;
+    position:absolute;
+    width:30%;
+    left:0px;
 }
 
 .datasheet{

--- a/src/app/components/input-load/input-load.component.html
+++ b/src/app/components/input-load/input-load.component.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <nav>
     <a routerLink="/input-load-name" routerLinkActive="selected-item" class="btn btn-outline-primary">荷重名称</a>
-    <a routerLink="/input-loads" routerLinkActive="selected-item" class="btn btn-outline-primary">荷重強度</a>
+    <a routerLink="/input-loads" routerLinkActive="selected-item" class="btn btn-outline-primary active">荷重強度</a>
   </nav>
 </div>
 

--- a/src/app/components/input-load/input-load.component.scss
+++ b/src/app/components/input-load/input-load.component.scss
@@ -1,8 +1,12 @@
 .btn-group {
-    width: 500px;
     margin-top: 15px;
     margin-bottom: 15px;
     margin-left: 15px;
+
+    display: inline-block;
+    position:absolute;
+    width:30%;
+    left:0px;
 }
 
 .pager {
@@ -15,6 +19,8 @@
     .ngb-pagination{
         float:left;
     }
+    
+    display: inline-block;
 }
 
 .datasheet{

--- a/src/app/components/input-nodes/input-nodes.component.html
+++ b/src/app/components/input-nodes/input-nodes.component.html
@@ -5,10 +5,13 @@
 
 <div class="datasheet">
     <hot-table class="hot" 
-    [settings]="hotTableSettings1" 
-    [data]="dataset1" 
-    [colHeaders]="true" 
-    [rowHeaders]="false">
+        [settings]="hotTableSettings1" 
+        [data]="dataset1" 
+        [colHeaders]="true" 
+        [rowHeaders]="false"
+        [width]="220" 
+        [height]="500"
+        >
         <hot-column data="id" [readOnly]="true" title="節点No"></hot-column>
         <hot-column data="x" title="X"></hot-column>
         <hot-column data="y" title="Y"></hot-column>
@@ -21,7 +24,10 @@
         [settings]="hotTableSettings2" 
         [data]="dataset2" 
         [colHeaders]="true" 
-        [rowHeaders]="false">
+        [rowHeaders]="false"
+        [width]="220" 
+        [height]="500"
+        >
         <hot-column data="id" [readOnly]="true" title="節点No"></hot-column>
         <hot-column data="x" title="X"></hot-column>
         <hot-column data="y" title="Y"></hot-column>
@@ -34,7 +40,10 @@
         [settings]="hotTableSettings3" 
         [data]="dataset3" 
         [colHeaders]="true" 
-        [rowHeaders]="false">
+        [rowHeaders]="false"
+        [width]="220" 
+        [height]="500"
+        >
         <hot-column data="id" [readOnly]="true" title="節点No"></hot-column>
         <hot-column data="x" title="X"></hot-column>
         <hot-column data="y" title="Y"></hot-column>

--- a/src/app/components/input-pickup/input-pickup.component.html
+++ b/src/app/components/input-pickup/input-pickup.component.html
@@ -2,7 +2,7 @@
   <nav>
     <a routerLink="/input-define" routerLinkActive="selected-item" class="btn btn-outline-primary">DEFINE</a>
     <a routerLink="/input-combine" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
-    <a routerLink="/input-pickup" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
+    <a routerLink="/input-pickup" routerLinkActive="selected-item" class="btn btn-outline-primary active">PICKUP</a>
   </nav>
 </div>
 
@@ -18,6 +18,7 @@
   [colHeaders]="true" 
   [rowHeaders]="rowHeaders" 
   [height]="500"
+  [width]="900"
   [settings]="hotTableSettings">
     <hot-column *ngFor="let c of pickupColums; index as i" [data]="c" [title]="pickupTitles[i]"></hot-column>
   </hot-table>

--- a/src/app/components/input-pickup/input-pickup.component.scss
+++ b/src/app/components/input-pickup/input-pickup.component.scss
@@ -1,8 +1,12 @@
 .btn-group {
-    width: 500px;
     margin-top: 15px;
     margin-bottom: 15px;
     margin-left: 15px;
+
+    display: inline-block;
+    position:absolute;
+    width:30%;
+    left:0px;
 }
 
 .pager {
@@ -12,6 +16,8 @@
     .pager-title{
         float:left;
     }
+
+    display: inline-block;
 }
 
 .datasheet{

--- a/src/app/components/login-dialog/login-dialog.component.html
+++ b/src/app/components/login-dialog/login-dialog.component.html
@@ -7,7 +7,7 @@
 <div class="modal-body">
   <div class="form-group">
     <label for="loginEmail">ユーザー名</label>
-    <input type="email" class="form-control" [(ngModel)]="loginUserName" placeholder="Username">
+    <input type="email" class="form-control" [(ngModel)]="loginUserName" placeholder="Username" id="user_name_id">
   </div>
   <div class="form-group">
     <label for="loginPassword">パスワード</label>

--- a/src/app/components/login-dialog/login-dialog.component.ts
+++ b/src/app/components/login-dialog/login-dialog.component.ts
@@ -26,6 +26,13 @@ export class LoginDialogComponent implements OnInit {
     }
 
   ngOnInit() {
+    //　エンターキーでログイン可能にする。
+    //　不要な場合は以下の処理を消してください。
+    document.body.onkeydown = (e)=> {
+      if (e.key === 'Enter') {
+        this.onClick();
+      }
+    }
   }
 
   onClick() {

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -1,6 +1,12 @@
 <div class="row">
+  <div class="col-xs-4 margin">
+      <div *ngIf="loggedIn" class="welcome-message">
+        {{loginUserName}}さん！あなたの保有ポイントは{{userPoint}}ポイントです
+      </div>
+    
+  </div>
 
-  <div class="col">
+  <div class="col-xs-4 margin">
     <div ngbDropdown class="d-inline-block">
       <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>ファイル</button>
       <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
@@ -20,16 +26,13 @@
     </div>
   </div>
 
-  <div class="col">
+  <div class="col-xs-4 margin">
     <div *ngIf="!loggedIn" class="d-inline-block">
       <button (click)="logIn()" class="btn btn-outline-primary">ログイン</button>
     </div>
     <div *ngIf="loggedIn" class="d-inline-block">
       <div class="logout-button">
         <button (click)="logOut()" class="btn btn-outline-primary">ログアウト</button>
-      </div>
-      <div class="welcome-message">
-        {{loginUserName}}さん！あなたの保有ポイントは{{userPoint}}ポイントです
       </div>
     </div>
   </div>

--- a/src/app/components/menu/menu.component.scss
+++ b/src/app/components/menu/menu.component.scss
@@ -4,3 +4,8 @@
 .welcome-message{
     display: flex;
 }
+
+.margin{
+    margin-left: 5px;
+    margin-right: 5px;
+}

--- a/src/app/components/menu/menu.component.ts
+++ b/src/app/components/menu/menu.component.ts
@@ -152,6 +152,9 @@ export class MenuComponent implements OnInit {
         this.userPoint = this.user.purchase_value.toString();
       }
     });
+
+    // 「ユーザー名」入力ボックスにフォーカスを当てる
+    document.getElementById("user_name_id").focus();
   }
 
   logOut(): void {

--- a/src/app/components/result-combine-disg/result-combine-disg.component.html
+++ b/src/app/components/result-combine-disg/result-combine-disg.component.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <nav>
     <a routerLink="/result-disg" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
-    <a routerLink="/result-comb_disg" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
+    <a routerLink="/result-comb_disg" routerLinkActive="selected-item" class="btn btn-outline-primary active">COMBINE</a>
     <a routerLink="/result-pic_disg" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>
 </div>

--- a/src/app/components/result-combine-fsec/result-combine-fsec.component.html
+++ b/src/app/components/result-combine-fsec/result-combine-fsec.component.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <nav>
     <a routerLink="/result-fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
-    <a routerLink="/result-comb_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
+    <a routerLink="/result-comb_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary active">COMBINE</a>
     <a routerLink="/result-pic_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>
 </div>

--- a/src/app/components/result-combine-reac/result-combine-reac.component.html
+++ b/src/app/components/result-combine-reac/result-combine-reac.component.html
@@ -1,7 +1,7 @@
 <div class="btn-group">
   <nav>
     <a routerLink="/result-reac" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
-    <a routerLink="/result-comb_reac" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
+    <a routerLink="/result-comb_reac" routerLinkActive="selected-item" class="btn btn-outline-primary active">COMBINE</a>
     <a routerLink="/result-pic_reac" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>
 </div>

--- a/src/app/components/result-disg/result-disg.component.html
+++ b/src/app/components/result-disg/result-disg.component.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
   <nav>
-    <a routerLink="/result-disg" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
+    <a routerLink="/result-disg" routerLinkActive="selected-item" class="btn btn-outline-primary active">基本ケース</a>
     <a routerLink="/result-comb_disg" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
     <a routerLink="/result-pic_disg" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>

--- a/src/app/components/result-fsec/result-fsec.component.html
+++ b/src/app/components/result-fsec/result-fsec.component.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
   <nav>
-    <a routerLink="/result-fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
+    <a routerLink="/result-fsec" routerLinkActive="selected-item" class="btn btn-outline-primary active">基本ケース</a>
     <a routerLink="/result-comb_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
     <a routerLink="/result-pic_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>

--- a/src/app/components/result-pickup-disg/result-pickup-disg.component.html
+++ b/src/app/components/result-pickup-disg/result-pickup-disg.component.html
@@ -2,7 +2,7 @@
   <nav>
     <a routerLink="/result-disg" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
     <a routerLink="/result-comb_disg" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
-    <a routerLink="/result-pic_disg" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
+    <a routerLink="/result-pic_disg" routerLinkActive="selected-item" class="btn btn-outline-primary active">PICKUP</a>
   </nav>
 </div>
 

--- a/src/app/components/result-pickup-fsec/result-pickup-fsec.component.html
+++ b/src/app/components/result-pickup-fsec/result-pickup-fsec.component.html
@@ -2,7 +2,7 @@
   <nav>
     <a routerLink="/result-fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
     <a routerLink="/result-comb_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
-    <a routerLink="/result-pic_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
+    <a routerLink="/result-pic_fsec" routerLinkActive="selected-item" class="btn btn-outline-primary active">PICKUP</a>
   </nav>
 </div>
 

--- a/src/app/components/result-pickup-reac/result-pickup-reac.component.html
+++ b/src/app/components/result-pickup-reac/result-pickup-reac.component.html
@@ -2,7 +2,7 @@
   <nav>
     <a routerLink="/result-reac" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
     <a routerLink="/result-comb_reac" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
-    <a routerLink="/result-pic_reac" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
+    <a routerLink="/result-pic_reac" routerLinkActive="selected-item" class="btn btn-outline-primary active">PICKUP</a>
   </nav>
 </div>
 

--- a/src/app/components/result-reac/result-reac.component.html
+++ b/src/app/components/result-reac/result-reac.component.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
   <nav>
-    <a routerLink="/result-reac" routerLinkActive="selected-item" class="btn btn-outline-primary">基本ケース</a>
+    <a routerLink="/result-reac" routerLinkActive="selected-item" class="btn btn-outline-primary active">基本ケース</a>
     <a routerLink="/result-comb_reac" routerLinkActive="selected-item" class="btn btn-outline-primary">COMBINE</a>
     <a routerLink="/result-pic_reac" routerLinkActive="selected-item" class="btn btn-outline-primary">PICKUP</a>
   </nav>

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,3 +10,42 @@ if (environment.production) {
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
+
+// WebGLのサイズをブラウザサイズに合わせて動的に変更する処理
+var canvas;
+var header;
+var container;
+
+//初期化
+function init() {
+  // WebGL本体が格納されているタグを取得
+  canvas = document.getElementById('#canvas');
+  
+  // ヘッダ領域を取得
+  header = document.getElementsByClassName('header');
+  container = document.getElementsByClassName('container');
+
+  setSize();
+}
+
+//サイズ変更処理
+function setSize() {
+  
+  // ヘッダ領域の分だけ縦幅を小さくするため、ヘッダサイズを取得する
+  var headerSize = container[0].clientHeight + header[0].clientHeight;
+  
+  canvas.style.width = window.innerWidth + 'px';
+  canvas.style.height = window.innerHeight - headerSize + 'px';
+}
+
+window.onload = function () {
+  init();
+};
+//ブラウザの大きさが変わった時に行う処理
+(function () {
+  window.onresize = function () {
+    setTimeout(function () {
+      setSize();
+    }, 200);
+  };
+}());


### PR DESCRIPTION
#9 WebGL ブラウザの大きさに合わせる
・初回時とブラウザサイズが変更された時にWebGLのキャンバスサイズを変更するようにしました。

#11 「荷重」と「組み合わせ」のボタンを横ならびにしました。
#11 「Tableにフォーカスがある時移動しない」を実装しました。
#11　Windowサイズを取得して contents-dailog の高さを決定するようにしました。
#11　contents-dialogの幅と高さをリサイズ可能にしました。ダイアログの一番右下端をドラッグすることでリサイズします。
#11　選択されているボタンにフォーカスを当てるようにしました。
#11　ログインボタン等が正常な位置に表示されるよう配置しました。
#11　ログイン画面を表示したときに Username にフォーカスがある状態にしました。
　　  また、エンターキーを叩いてもログインできるようにしてみました。
　　（フォーカスが当たるようになった途端、エンターでログインできないのがかなり不便に感じたため）